### PR TITLE
Task: Normalize tmLanguage JSON file

### DIFF
--- a/syntaxes/fusion.tmLanguage.json
+++ b/syntaxes/fusion.tmLanguage.json
@@ -1,489 +1,531 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Fusion",
-  "patterns": [
-		{
-			"include": "#comments"
-		},
-    {
-      "include": "#operators"
-    },
-    {
-      "include": "#prototype-definition"
-		},
-    {
-      "include": "#include"
-		},
-		{
-      "include": "#property-definition"
-    }
-  ],
-  "repository": {
-		"comments": {
-			"patterns": [{
-				"name": "comment.block.fusion",
-				"begin": "/\\*",
-				"beginCaptures": {
-					"0": {
-						"name": "punctuation.definition.comment.begin.fusion"
-					}
-				},
-				"end": "\\*/",
-				"endCaptures": {
-					"0": {
-						"name": "punctuation.definition.comment.end.fusion"
-					}
-				}
-			}, {
-				"begin": "(^[ \t]+)?(?=//)",
-				"beginCaptures": {
-					"1": {
-						"name": "punctuation.whitespace.comment.leading.fusion"
-					}
-				},
-				"end": "(?!\\G)",
-				"patterns": [{
-					"name": "comment.line.double-slash.fusion",
-					"begin": "//",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.comment.fusion"
-						}
-					},
-					"end": "\n"
-				}]
-			}, {
-				"begin": "(^[ \t]+)?(?=#)",
-				"beginCaptures": {
-					"1": {
-						"name": "punctuation.whitespace.comment.leading.fusion"
-					}
-				},
-				"end": "(?!\\G)",
-				"patterns": [{
-					"name": "comment.line.hash.fusion",
-					"begin": "#",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.comment.fusion"
-						}
-					},
-					"end": "\n"
-				}]
-			}]
-		},
-    "operators": {
-      "patterns": [
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Fusion",
+    "patterns": [
         {
-          "name": "keyword.operator.fusion",
-          "match": "\\b(<|>|=)\\b"
-        }
-      ]
-    },
-    "strings": {
-      "patterns": [
-        {
-          "name": "string.quoted.double.fusion",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [
-            {
-              "name": "constant.character.escape.fusion",
-              "match": "\\\\."
-            }
-          ]
+            "include": "#comments"
         },
         {
-          "name": "string.quoted.single.fusion",
-          "begin": "'",
-          "end": "'",
-          "patterns": [
-            {
-              "name": "constant.character.escape.fusion",
-              "match": "\\\\."
-            }
-          ]
-        }
-      ]
-		},
-    "prototype-definition": {
-      "begin": "(prototype)\\(",
-      "end": "\\)",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.other.fusion"
-        }
-      },
-      "patterns": [
+            "include": "#operators"
+        },
         {
-          "include": "#object-name"
+            "include": "#prototype-definition"
+        },
+        {
+            "include": "#include"
+        },
+        {
+            "include": "#property-definition"
         }
-      ]
-		},
-		"expression": {
-			"begin": "(\\$\\{)",
-			"end": "(\\})",
-			"beginCaptures": {
-				"1": {
-					"name": "keyword.other.fusion"
-				}
-			},
-			"endCaptures": {
-				"1": {
-					"name": "keyword.other.fusion"
-				}
-			},
-			"patterns": [{
-				"include": "source.js#expression"
-			}]
-		},
-		"preprocessor": {
-			"patterns": [{
-				"begin": "(afx)(`)",
-				"beginCaptures": {
-					"1": {
-						"name": "support.function.fusion"
-					},
-					"2": {
-						"name": "string.quoted.other"
-					}
-				},
-				"end": "(`)",
-				"endCaptures": {
-					"1": {
-						"name": "string.quoted.other"
-					}
-				},
-				"patterns": [{
-					"include": "#afx"
-				}]
-			}, {
-				"name": "string.quoted.other.fusion",
-				"begin": "([a-zA-Z_-]+)`",
-				"beginCaptures": {
-					"1": {
-						"name": "support.function.fusion"
-					}
-				},
-				"end": "(`)"
-			}]
-		},
-		"property-path": {
-			"patterns": [{
-				"begin": "(@[a-zA-Z0-9:_\\-]+)|([a-zA-Z0-9:_\\-]+)",
-				"beginCaptures": {
-					"1": {
-						"name": "entity.other.attribute-name.fusion"
-					},
-					"2": {
-						"name": "variable.other.fusion"
-					}
-				},
-				"end": "\\G",
-				"patterns": [{
-					"match": "\\."
-				}, {
-					"include": "#prototype-definition"
-				}, {
-					"include": "#strings"
-				}]
-			}]
-		},
-		"property-definition": {
-			"patterns": [{
-				"include": "#property-path"
-			}, {
-				"begin": "=\\s*",
-				"end": "(?!\\G)",
-				"patterns": [{
-					"include": "#preprocessor"
-				}, {
-					"include": "#strings"
-				}, {
-					"include": "#expression"
-				}, {
-					"include": "#boolean-literal"
-				}, {
-					"include": "#null-literal"
-				}, {
-					"include": "#numeric-literal"
-				}, {
-					"include": "#object-name"
-				}]
-			}]
-		},
-		"object-name": {
-			"patterns": [{
-				"match": "[a-zA-Z0-9.:]+",
-				"name": "entity.name.type.fusion"
-			}]
-		},
-		"boolean-literal": {
-			"patterns": [{
-				"match": "(TRUE|FALSE|true|false)",
-				"name": "constant.language.fusion"
-			}]
-		},
-		"numeric-literal": {
-			"patterns": [{
-				"match": "-?\\d+(\\.\\d+)?",
-				"name": "constant.numeric.fusion"
-			}]
-		},
-		"null-literal": {
-			"patterns": [{
-				"match": "(NULL|null)",
-				"name": "constant.other.fusion"
-			}]
-		},
-		"include": {
-			"patterns": [{
-				"match": "^(include):\\s*(.*)\\s*$",
-				"captures": {
-					"1": {
-						"name": "keyword.other.fusion"
-					},
-					"2": {
-						"name": "string.unquoted"
-					}
-				}
-			}]
-		},
-
-		"afx": {
-			"patterns": [
-				{
-					"include": "#afx-comments"
-				},
-				{
-					"begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.tag.xml"
-						},
-						"2": {
-							"name": "entity.name.tag.xml"
-						},
-						"3": {
-							"name": "entity.name.tag.namespace.xml"
-						},
-						"4": {
-							"name": "punctuation.separator.namespace.xml"
-						},
-						"5": {
-							"name": "entity.name.tag.localname.xml"
-						}
-					},
-					"end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.tag.xml"
-						},
-						"2": {
-							"name": "punctuation.definition.tag.xml"
-						},
-						"3": {
-							"name": "entity.name.tag.xml"
-						},
-						"4": {
-							"name": "entity.name.tag.namespace.xml"
-						},
-						"5": {
-							"name": "punctuation.separator.namespace.xml"
-						},
-						"6": {
-							"name": "entity.name.tag.localname.xml"
-						},
-						"7": {
-							"name": "punctuation.definition.tag.xml"
-						}
-					},
-					"name": "meta.tag.no-content.xml",
-					"patterns": [
-						{
-							"include": "#afx-tagStuff"
-						}
-					]
-				},
-				{
-					"begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
-					"captures": {
-						"1": {
-							"name": "punctuation.definition.tag.xml"
-						},
-						"2": {
-							"name": "entity.name.tag.namespace.xml"
-						},
-						"3": {
-							"name": "entity.name.tag.xml"
-						},
-						"4": {
-							"name": "punctuation.separator.namespace.xml"
-						},
-						"5": {
-							"name": "entity.name.tag.localname.xml"
-						}
-					},
-					"end": "(/?>)",
-					"name": "meta.tag.xml",
-					"patterns": [
-						{
-							"include": "#afx-tagStuff"
-						}
-					]
-				},
-				{
-					"include": "#afx-entity"
-				},
-				{
-					"include": "#afx-bare-ampersand"
-				},
-				{
-					"begin": "<!\\[CDATA\\[",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.xml"
-						}
-					},
-					"end": "]]>",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.xml"
-						}
-					},
-					"name": "string.unquoted.cdata.xml"
-				}
-			]
-		},
-
-		"afx-bare-ampersand": {
-			"match": "&",
-			"name": "invalid.illegal.bad-ampersand.xml"
-		},
-		"afx-doublequotedString": {
-			"begin": "\"",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.begin.xml"
-				}
-			},
-			"end": "\"",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.end.xml"
-				}
-			},
-			"name": "string.quoted.double.xml",
-			"patterns": [
-				{
-					"include": "#afx-entity"
-				},
-				{
-					"include": "#afx-bare-ampersand"
-				}
-			]
-		},
-		"afx-entity": {
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.constant.xml"
-				},
-				"3": {
-					"name": "punctuation.definition.constant.xml"
-				}
-			},
-			"match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
-			"name": "constant.character.entity.xml"
-		},
-		"afx-parameterEntity": {
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.constant.xml"
-				},
-				"3": {
-					"name": "punctuation.definition.constant.xml"
-				}
-			},
-			"match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
-			"name": "constant.character.parameter-entity.xml"
-		},
-		"afx-singlequotedString": {
-			"begin": "'",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.begin.xml"
-				}
-			},
-			"end": "'",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.end.xml"
-				}
-			},
-			"name": "string.quoted.single.xml",
-			"patterns": [
-				{
-					"include": "#afx-entity"
-				},
-				{
-					"include": "#afx-bare-ampersand"
-				}
-			]
-		},
-		"afx-tagStuff": {
-			"patterns": [
-				{
-					"captures": {
-						"1": {
-							"name": "entity.other.attribute-name.namespace.xml"
-						},
-						"2": {
-							"name": "entity.other.attribute-name.xml"
-						},
-						"3": {
-							"name": "punctuation.separator.namespace.xml"
-						},
-						"4": {
-							"name": "entity.other.attribute-name.localname.xml"
-						}
-					},
-					"match": "(?:^|\\s+)(?:([-\\w@.]+)((:)))?([-\\w@.:]+)\\s*="
-				},
-				{
-					"include": "#afx-doublequotedString"
-				},
-				{
-					"include": "#afx-singlequotedString"
-				},
-				{
-					"begin": "(\\{)",
-					"end": "(\\})",
-					"beginCaptures": {
-						"1": {
-							"name": "keyword.other.fusion"
-						}
-					},
-					"endCaptures": {
-						"1": {
-							"name": "keyword.other.fusion"
-						}
-					},
-					"patterns": [{
-						"include": "source.js#expression"
-					}]
-				}
-			]
-		},
-		"afx-comments": {
-			"begin": "<[!%]--",
-			"captures": {
-				"0": {
-					"name": "punctuation.definition.comment.xml"
-				}
-			},
-			"end": "--%?>",
-			"name": "comment.block.xml"
-		}
-  },
-  "scopeName": "source.fusion"
+    ],
+    "repository": {
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.block.fusion",
+                    "begin": "/\\*",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.begin.fusion"
+                        }
+                    },
+                    "end": "\\*/",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.end.fusion"
+                        }
+                    }
+                },
+                {
+                    "begin": "(^[ \t]+)?(?=//)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.whitespace.comment.leading.fusion"
+                        }
+                    },
+                    "end": "(?!\\G)",
+                    "patterns": [
+                        {
+                            "name": "comment.line.double-slash.fusion",
+                            "begin": "//",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.comment.fusion"
+                                }
+                            },
+                            "end": "\n"
+                        }
+                    ]
+                },
+                {
+                    "begin": "(^[ \t]+)?(?=#)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.whitespace.comment.leading.fusion"
+                        }
+                    },
+                    "end": "(?!\\G)",
+                    "patterns": [
+                        {
+                            "name": "comment.line.hash.fusion",
+                            "begin": "#",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.comment.fusion"
+                                }
+                            },
+                            "end": "\n"
+                        }
+                    ]
+                }
+            ]
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "name": "keyword.operator.fusion",
+                    "match": "\\b(<|>|=)\\b"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "name": "string.quoted.double.fusion",
+                    "begin": "\"",
+                    "end": "\"",
+                    "patterns": [
+                        {
+                            "name": "constant.character.escape.fusion",
+                            "match": "\\\\."
+                        }
+                    ]
+                },
+                {
+                    "name": "string.quoted.single.fusion",
+                    "begin": "'",
+                    "end": "'",
+                    "patterns": [
+                        {
+                            "name": "constant.character.escape.fusion",
+                            "match": "\\\\."
+                        }
+                    ]
+                }
+            ]
+        },
+        "prototype-definition": {
+            "begin": "(prototype)\\(",
+            "end": "\\)",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.other.fusion"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#object-name"
+                }
+            ]
+        },
+        "expression": {
+            "begin": "(\\$\\{)",
+            "end": "(\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.other.fusion"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "keyword.other.fusion"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "source.js#expression"
+                }
+            ]
+        },
+        "preprocessor": {
+            "patterns": [
+                {
+                    "begin": "(afx)(`)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.fusion"
+                        },
+                        "2": {
+                            "name": "string.quoted.other"
+                        }
+                    },
+                    "end": "(`)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "string.quoted.other"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#afx"
+                        }
+                    ]
+                },
+                {
+                    "name": "string.quoted.other.fusion",
+                    "begin": "([a-zA-Z_-]+)`",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.fusion"
+                        }
+                    },
+                    "end": "(`)"
+                }
+            ]
+        },
+        "property-path": {
+            "patterns": [
+                {
+                    "begin": "(@[a-zA-Z0-9:_\\-]+)|([a-zA-Z0-9:_\\-]+)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "entity.other.attribute-name.fusion"
+                        },
+                        "2": {
+                            "name": "variable.other.fusion"
+                        }
+                    },
+                    "end": "\\G",
+                    "patterns": [
+                        {
+                            "match": "\\."
+                        },
+                        {
+                            "include": "#prototype-definition"
+                        },
+                        {
+                            "include": "#strings"
+                        }
+                    ]
+                }
+            ]
+        },
+        "property-definition": {
+            "patterns": [
+                {
+                    "include": "#property-path"
+                },
+                {
+                    "begin": "=\\s*",
+                    "end": "(?!\\G)",
+                    "patterns": [
+                        {
+                            "include": "#preprocessor"
+                        },
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "include": "#expression"
+                        },
+                        {
+                            "include": "#boolean-literal"
+                        },
+                        {
+                            "include": "#null-literal"
+                        },
+                        {
+                            "include": "#numeric-literal"
+                        },
+                        {
+                            "include": "#object-name"
+                        }
+                    ]
+                }
+            ]
+        },
+        "object-name": {
+            "patterns": [
+                {
+                    "match": "[a-zA-Z0-9.:]+",
+                    "name": "entity.name.type.fusion"
+                }
+            ]
+        },
+        "boolean-literal": {
+            "patterns": [
+                {
+                    "match": "(TRUE|FALSE|true|false)",
+                    "name": "constant.language.fusion"
+                }
+            ]
+        },
+        "numeric-literal": {
+            "patterns": [
+                {
+                    "match": "-?\\d+(\\.\\d+)?",
+                    "name": "constant.numeric.fusion"
+                }
+            ]
+        },
+        "null-literal": {
+            "patterns": [
+                {
+                    "match": "(NULL|null)",
+                    "name": "constant.other.fusion"
+                }
+            ]
+        },
+        "include": {
+            "patterns": [
+                {
+                    "match": "^(include):\\s*(.*)\\s*$",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.fusion"
+                        },
+                        "2": {
+                            "name": "string.unquoted"
+                        }
+                    }
+                }
+            ]
+        },
+        "afx": {
+            "patterns": [
+                {
+                    "include": "#afx-comments"
+                },
+                {
+                    "begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.xml"
+                        },
+                        "2": {
+                            "name": "entity.name.tag.xml"
+                        },
+                        "3": {
+                            "name": "entity.name.tag.namespace.xml"
+                        },
+                        "4": {
+                            "name": "punctuation.separator.namespace.xml"
+                        },
+                        "5": {
+                            "name": "entity.name.tag.localname.xml"
+                        }
+                    },
+                    "end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.xml"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.tag.xml"
+                        },
+                        "3": {
+                            "name": "entity.name.tag.xml"
+                        },
+                        "4": {
+                            "name": "entity.name.tag.namespace.xml"
+                        },
+                        "5": {
+                            "name": "punctuation.separator.namespace.xml"
+                        },
+                        "6": {
+                            "name": "entity.name.tag.localname.xml"
+                        },
+                        "7": {
+                            "name": "punctuation.definition.tag.xml"
+                        }
+                    },
+                    "name": "meta.tag.no-content.xml",
+                    "patterns": [
+                        {
+                            "include": "#afx-tagStuff"
+                        }
+                    ]
+                },
+                {
+                    "begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.tag.xml"
+                        },
+                        "2": {
+                            "name": "entity.name.tag.namespace.xml"
+                        },
+                        "3": {
+                            "name": "entity.name.tag.xml"
+                        },
+                        "4": {
+                            "name": "punctuation.separator.namespace.xml"
+                        },
+                        "5": {
+                            "name": "entity.name.tag.localname.xml"
+                        }
+                    },
+                    "end": "(/?>)",
+                    "name": "meta.tag.xml",
+                    "patterns": [
+                        {
+                            "include": "#afx-tagStuff"
+                        }
+                    ]
+                },
+                {
+                    "include": "#afx-entity"
+                },
+                {
+                    "include": "#afx-bare-ampersand"
+                },
+                {
+                    "begin": "<!\\[CDATA\\[",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.xml"
+                        }
+                    },
+                    "end": "]]>",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.xml"
+                        }
+                    },
+                    "name": "string.unquoted.cdata.xml"
+                }
+            ]
+        },
+        "afx-bare-ampersand": {
+            "match": "&",
+            "name": "invalid.illegal.bad-ampersand.xml"
+        },
+        "afx-doublequotedString": {
+            "begin": "\"",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.quoted.double.xml",
+            "patterns": [
+                {
+                    "include": "#afx-entity"
+                },
+                {
+                    "include": "#afx-bare-ampersand"
+                }
+            ]
+        },
+        "afx-entity": {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+            "name": "constant.character.entity.xml"
+        },
+        "afx-parameterEntity": {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
+            "name": "constant.character.parameter-entity.xml"
+        },
+        "afx-singlequotedString": {
+            "begin": "'",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "'",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.quoted.single.xml",
+            "patterns": [
+                {
+                    "include": "#afx-entity"
+                },
+                {
+                    "include": "#afx-bare-ampersand"
+                }
+            ]
+        },
+        "afx-tagStuff": {
+            "patterns": [
+                {
+                    "captures": {
+                        "1": {
+                            "name": "entity.other.attribute-name.namespace.xml"
+                        },
+                        "2": {
+                            "name": "entity.other.attribute-name.xml"
+                        },
+                        "3": {
+                            "name": "punctuation.separator.namespace.xml"
+                        },
+                        "4": {
+                            "name": "entity.other.attribute-name.localname.xml"
+                        }
+                    },
+                    "match": "(?:^|\\s+)(?:([-\\w@.]+)((:)))?([-\\w@.:]+)\\s*="
+                },
+                {
+                    "include": "#afx-doublequotedString"
+                },
+                {
+                    "include": "#afx-singlequotedString"
+                },
+                {
+                    "begin": "(\\{)",
+                    "end": "(\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.fusion"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.other.fusion"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "source.js#expression"
+                        }
+                    ]
+                }
+            ]
+        },
+        "afx-comments": {
+            "begin": "<[!%]--",
+            "captures": {
+                "0": {
+                    "name": "punctuation.definition.comment.xml"
+                }
+            },
+            "end": "--%?>",
+            "name": "comment.block.xml"
+        }
+    },
+    "scopeName": "source.fusion"
 }


### PR DESCRIPTION
I found it hard to read the tmLanguage file because different levels in the JSON structure were not indented to the same level.

This PR fixes that.

The contents of the file were not changed - only the indention.